### PR TITLE
refactor: use `class` instead of `className`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Chessground can be completely restyled through CSS. The component imports defaul
             }
         </style>
 
-2. Apply your own full chessground stylesheet instead of the defaults by setting the `className` prop and importing your own stylesheet.
+2. Apply your own full chessground stylesheet instead of the defaults by setting the `class` prop and importing your own stylesheet.
 By changing the class name from the default, none of the default stylesheets will apply, not even the piece SVGs.
 Additionally, you can use the provided `ChessgroundUnstyled` component, which is completely unstyled.
 
@@ -67,7 +67,7 @@ Additionally, you can use the provided `ChessgroundUnstyled` component, which is
             import {ChessgroundUnstyled} from 'svelte-chessground';
             import '$lib/my-chessboard.css';
         </script>
-        <ChessgroundUnstyled className="my-chessboard" />
+        <ChessgroundUnstyled class="my-chessboard" />
 
 You can find working code for both approaches in the [custom styles examples](https://github.com/gtim/svelte-chessground-examples/blob/main/src/routes/style/%2Bpage.svelte).
 

--- a/src/lib/Chessground.svelte
+++ b/src/lib/Chessground.svelte
@@ -21,7 +21,8 @@
 	 * stylesheet than the default.
 	 * @type {string}
 	 */
-	export let className = 'cg-default-style';
+	let className = 'cg-default-style';
+	export { className as class };
 
 	/** 
 	 * Chess position in Forsyth-Edwards notation.

--- a/src/lib/ChessgroundUnstyled.svelte
+++ b/src/lib/ChessgroundUnstyled.svelte
@@ -23,7 +23,8 @@
 	 * stylesheet than the default.
 	 * @type {string}
 	 */
-	export let className = 'cg-default-style';
+	let className = 'cg-default-style';
+	export { className as class };
 
 	/** 
 	 * Chess position in Forsyth-Edwards notation.


### PR DESCRIPTION
Same as [https://github.com/gtim/svelte-chess/pull/1](https://github.com/gtim/svelte-chess/pull/1) to keep consistency between projects.